### PR TITLE
Fix required phpstan version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7",
-        "phpstan/phpstan": "0.9.x-dev"
+        "phpstan/phpstan": "^0.9"
     },
     "require-dev": {
         "eloquent/phony": "^2.0",


### PR DESCRIPTION
Version 0.1 cannot be installed with stable phpstan 0.9 because of this error:

```
  Problem 1
    - Installation request for eloquent/phpstan-phony ^0.1.0 -> satisfiable by eloquent/phpstan-phony[0.1.0].
    - eloquent/phpstan-phony 0.1.0 requires phpstan/phpstan 0.9.x-dev -> satisfiable by phpstan/phpstan[0.9.x-dev] but these conflict with your requirements or minimum-stability.

```

By the correct way to write the requirement before 0.9 became stable was not `0.9.x-dev` but `^0.9@dev`.