### PR TITLE
Enable phpstan 0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "type": "phpstan-extension",
     "require": {
         "php": ">=7.2",
-        "phpstan/phpstan": "^0.11"
+        "phpstan/phpstan": "^0.11 || ^0.12"
     },
     "require-dev": {
         "eloquent/code-style": "^1",


### PR DESCRIPTION
Not sure if there are any BC breaks. Just wanna see what CI says. Maybe we'll have to drop the 0.11 support.